### PR TITLE
Fix: prerelease numeric identifiers must not start with 0

### DIFF
--- a/semver
+++ b/semver
@@ -10,8 +10,8 @@ use warnings;
 use feature qw(say);
 use Scalar::Util qw(looks_like_number);
 
-# Regex adapted from semver.org: https://github.com/semver/semver/pull/460
-my $semver_regex = '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:\-([0-9a-zA-Z-]+(?:\.(?:0|[1-9a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$';
+# Regex from semver.org: https://github.com/semver/semver/pull/460
+my $semver_regex = '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$';
 my $semver_precedence_regex_head = '^([0-9a-zA-Z-]*)';
 my $semver_precedence_regex_tail = '\.(0|[1-9a-zA-Z-][0-9a-zA-Z-]*)';
 

--- a/test/validate.bats
+++ b/test/validate.bats
@@ -328,8 +328,6 @@ should_reject() {
 }
 
 @test 'validate: 1.0.0-01 should fail' {
-    skip 'TODO check - this might be allowed by the spec as it is not a dotted numeric identifier'
-
     should_reject '1.0.0-01'
 }
 


### PR DESCRIPTION
Address the remaining skipped test for numeric identifiers in the prerelease component.

Fix #8 