### PR TITLE
Use Codecov Action v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,6 @@ jobs:
         run: make test
         env:
           PERL5OPT: '-MDevel::Cover'
-      - uses: codecov/codecov-action@v2
+      - name: Coverage report
+        run: cover
+      - uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,4 @@ jobs:
         run: make test
         env:
           PERL5OPT: '-MDevel::Cover'
-      - name: Coverage report
-        # TODO: this should be 'cover -report codecov' but the Codecov uploader does not support GitHub Actions yet
-        # see https://github.com/codecov/codecov-perl/pull/41 for details
-        run: cover
+      - uses: codecov/codecov-action@v2


### PR DESCRIPTION
Use the new Codecov Action v2, as the v1 uploaders (including the Perl uploader) will stop working in early 2022.